### PR TITLE
Allow for pre-selections to be made & add test cases

### DIFF
--- a/test/searchable_select_test.exs
+++ b/test/searchable_select_test.exs
@@ -164,6 +164,27 @@ defmodule SearchableSelect.SearchableSelectTest do
     assert_push_event(live, "searchable_select", %{id: ^hook_id})
   end
 
+  test "pre-selection made, form mode, multiple=false", %{live: live} do
+    assert has_element?(live, "#single_form_preselected-option-1")
+    assert has_element?(live, "#single_form_preselected-option-2")
+    refute has_element?(live, "#single_form_preselected-option-3")
+    assert has_element?(live, "#single_form_preselected-option-4")
+  end
+
+  test "pre-selection made, non-form mode, multiple=false", %{live: live} do
+    assert has_element?(live, "#single_preselected-option-1")
+    assert has_element?(live, "#single_preselected-option-2")
+    assert has_element?(live, "#single_preselected-option-3")
+    refute has_element?(live, "#single_preselected-option-4")
+  end
+
+  test "pre-selection made on invalid element", %{live: live} do
+    assert has_element?(live, "#single_invalid_preselect-option-1")
+    assert has_element?(live, "#single_invalid_preselect-option-2")
+    assert has_element?(live, "#single_invalid_preselect-option-3")
+    assert has_element?(live, "#single_invalid_preselect-option-4")
+  end
+
   defp load_test_view(_) do
     {:ok, live, _html} = live_isolated(conn(:get, "/"), SearchableSelect.TestView)
     %{live: live}

--- a/test/support/test_view.ex
+++ b/test/support/test_view.ex
@@ -55,6 +55,13 @@ defmodule SearchableSelect.TestView do
       parent_key="selected_options"
     />
     <.live_component
+      id="single_preselected"
+      module={SearchableSelect}
+      options={@options}
+      parent_key="selected_options"
+      preselected_id={4}
+    />
+    <.live_component
       dropdown
       id="dropdown"
       module={SearchableSelect}
@@ -78,7 +85,21 @@ defmodule SearchableSelect.TestView do
         multiple
         options={@options}
       />
+      <.live_component
+        id="single_form_preselected"
+        module={SearchableSelect}
+        options={@options}
+        parent_key="selected_options"
+        preselected_id={3}
+      />
     </.form>
+    <.live_component
+      id="single_invalid_preselect"
+      module={SearchableSelect}
+      options={@options}
+      parent_key="selected_options"
+      preselected_id={99}
+    />
     """
   end
 end


### PR DESCRIPTION
For Edit forms etc, needed the ability to load this component with an option already selected (instead of nothing as before).

To do this, pass the `:id` of the desired item as the SearchableSelect's`preselected_id`

For example, in form mode:
```elixir
        <.input_group
          id={"product-select-#{@product_id}"}
          form={f}
          field={:product_id}
          type={:searchable_select}
          options={@options}
          preselected_id={123}
        />
```
...then, the page is loaded with a selection already made: 
<img width="601" alt="image" src="https://user-images.githubusercontent.com/59553710/196192362-b6040f78-1bea-43d2-a656-afe0c5ccc205.png">


Example of non-form mode:
```elixir
      <.live_component
        id={"product-select-#{@product_id}"}
        module={SearchableSelect}
        options={@options}
        parent_key={:product_id}
        preselected_id={123}
      />
```

Notes:
- Intentionally does not fire a handle_info or "validate" event to parent view during initial rendering. Only does so once user changes or clears selection.
- Works for single-select only (ignores preselected_id if `multiple: true`)
- Providing nil or an ID which can't be found, results in the preselection being ignored; the component starts without any item selected.