### PR TITLE
Add `send_search_events` and `no_matching_options_text` attrs

### DIFF
--- a/lib/searchable_select.ex
+++ b/lib/searchable_select.ex
@@ -33,6 +33,8 @@ defmodule SearchableSelect do
   label_callback - Function used to populate label when displaying items. Defaults to `fn item -> item.name end`
   multiple - True=multiple options may be selected, False=only one option may be select - optional, defaults to `false`
   options - List of maps or structs to use as options - required
+  no_matching_options_text - Text to display if a search is entered but there are no matching options.
+    Defaults to: "Sorry, no matching options."
   parent_key - Key to send to parent view when options are selected/unselected - required unless form is set
   placeholder - Placeholder for the search input, defaults to "Search"
   preselected_id - Used to populate the component with an already-selected option upon first render. Only for `multiple: false`.
@@ -40,19 +42,19 @@ defmodule SearchableSelect do
   preselected_ids - Used to populate the component with already-selected options upon first render. Only for `multiple: true`.
     Specify a list of `id`s of the desired options, defaults to [] (no pre-selection occurs).
   value_callback - Function used to populate the hidden input when form is set. Defaults to `fn item -> item.id end`
+  send_search_events - If set, this Component sends a `{:search, "tag", search_string}`
+    message whenever its search string changes. Defaults to false.
   sort_callback - Either :asc or :desc and optional module to use for compare refer to Enum.sort_by/3
   sort_mapping_callback - Function for mapping of value to sort by, refer to Enum.sort_by/3
-  no_matching_options_text - TODO
-  send_search_events - TODO
   """
   @impl true
   # this is when assigns change after the component is mounted
   def update(assigns, %{assigns: %{id: _id}} = socket) do
     socket =
       socket
-      |> assign(:search, "")
       |> assign(:disabled, assigns[:disabled])
       |> assign(:placeholder, assigns[:placeholder] || "Search")
+      |> assign(:search, "")
       |> then(&pre_select(&1, Map.merge(&1.assigns, assigns)))
       |> prep_options(assigns)
 
@@ -73,10 +75,7 @@ defmodule SearchableSelect do
     |> assign(:id, assigns.id)
     |> assign(:label_callback, assigns[:label_callback] || fn item -> item.name end)
     |> assign(:multiple, assigns[:multiple] || false)
-    |> assign(
-      :no_matching_options_text,
-      assigns[:no_matching_options_text] || "Sorry, no matching options."
-    )
+    |> assign(:no_matching_options_text, assigns[:no_matching_options_text])
     |> assign(:parent_key, assigns[:parent_key])
     |> assign(:placeholder, assigns[:placeholder] || "Search")
     |> assign(:search, "")

--- a/lib/searchable_select.ex
+++ b/lib/searchable_select.ex
@@ -42,7 +42,7 @@ defmodule SearchableSelect do
   preselected_ids - Used to populate the component with already-selected options upon first render. Only for `multiple: true`.
     Specify a list of `id`s of the desired options, defaults to [] (no pre-selection occurs).
   value_callback - Function used to populate the hidden input when form is set. Defaults to `fn item -> item.id end`
-  send_search_events - If set, this Component sends a `{:search, "tag", search_string}`
+  send_search_events - If set, this Component sends a `{:search, key, search_string}`
     message whenever its search string changes. Defaults to false.
   sort_callback - Either :asc or :desc and optional module to use for compare refer to Enum.sort_by/3
   sort_mapping_callback - Function for mapping of value to sort by, refer to Enum.sort_by/3

--- a/lib/searchable_select.html.heex
+++ b/lib/searchable_select.html.heex
@@ -78,7 +78,7 @@
                 <%= if String.trim(@search) == "" do
                   "No more options."
                 else
-                  @no_matching_options_text
+                  @no_matching_options_text || "Sorry, no matching options."
                 end %>
               </div>
             </div>

--- a/lib/searchable_select.html.heex
+++ b/lib/searchable_select.html.heex
@@ -75,11 +75,11 @@
           <div class="w-full border-gray-200 border-b">
             <div class="flex w-full items-center p-2 pl-2 border-transparent border-l-2 relative">
               <div class="w-full items-center flex justify-between">
-                <%= if String.trim(@search) == "" do %>
-                  No more options.
-                <% else %>
-                  Sorry, no matching options.
-                <% end %>
+                <%= if String.trim(@search) == "" do
+                  "No more options."
+                else
+                  @no_matching_options_text
+                end %>
               </div>
             </div>
           </div>

--- a/test/searchable_select_test.exs
+++ b/test/searchable_select_test.exs
@@ -34,6 +34,24 @@ defmodule SearchableSelect.SearchableSelectTest do
     Enum.each(1..4, fn i -> refute has_element?(live, "#multi-option-#{i}") end)
   end
 
+  test "no results message shows if no items available - custom no_matching_options_text", %{
+    live: live
+  } do
+    html =
+      live
+      |> element("#multi_custom_no_matching_options_text-search")
+      |> render_keyup(%{"value" => "asdf"})
+
+    assert html =~ "These aren&#39;t the droids you&#39;re looking for..."
+
+    Enum.each(1..4, fn i ->
+      refute has_element?(live, "#multi_custom_no_matching_options_text-option-#{i}")
+    end)
+
+    assert "<p id=\"last_search_message_params_p\">\n  {&quot;selected_options&quot;, &quot;asdf&quot;}\n</p>" =
+             live |> element("#last_search_message_params_p") |> render()
+  end
+
   test "can select multiple items if multiple=true", %{live: live} do
     live |> element("#multi-option-1") |> render_click()
     live |> element("#multi-option-2") |> render_click()

--- a/test/support/test_view.ex
+++ b/test/support/test_view.ex
@@ -15,6 +15,7 @@ defmodule SearchableSelect.TestView do
 
     socket =
       socket
+      |> assign(:last_search_message_params, nil)
       |> assign(:options, example_options)
       |> assign(:selected_options, [])
 
@@ -34,6 +35,12 @@ defmodule SearchableSelect.TestView do
     |> then(&{:noreply, &1})
   end
 
+  def handle_info({:search, key, search_string}, socket) do
+    socket
+    |> assign(:last_search_message_params, {key, search_string})
+    |> then(&{:noreply, &1})
+  end
+
   defp get_selected_id_list([]), do: "[]"
   defp get_selected_id_list([%{id: id}]), do: "[#{id}]"
   defp get_selected_id_list(nil), do: "nil"
@@ -49,6 +56,15 @@ defmodule SearchableSelect.TestView do
       multiple
       options={@options}
       parent_key="selected_options"
+    />
+    <.live_component
+      id="multi_custom_no_matching_options_text"
+      module={SearchableSelect}
+      multiple
+      options={@options}
+      parent_key="selected_options"
+      no_matching_options_text="These aren't the droids you're looking for..."
+      send_search_events
     />
     <.live_component
       id="single"
@@ -125,6 +141,10 @@ defmodule SearchableSelect.TestView do
       parent_key="selected_options"
       preselected_ids={[98, 99]}
     />
+
+    last_search_message_params: <p id="last_search_message_params_p">
+      <%= inspect(@last_search_message_params) %>
+    </p>
     """
   end
 end


### PR DESCRIPTION
1. Add `send_search_events` option:
   If set, the Componant forwards info about its search events to the parent liveview, which can handle it like so:
   ```elixir
   def handle_info({:search, "tag", search_str}, socket), do: ...
   ```
1. Add `no_matching_options_text` option:
   This is just so you can have custom text if your search yields no results, otherwise the default `"Sorry, no matching options."` is still displayed
1. Ran formatter and alphabetised a lil bit.