### PR TITLE
Allow duplicate (normalised) labels

### DIFF
--- a/test/support/test_view.ex
+++ b/test/support/test_view.ex
@@ -10,7 +10,8 @@ defmodule SearchableSelect.TestView do
       %{id: 3, name: "Foo"},
       %{id: 4, name: "Lmao"},
       %{id: 5, name: "Biz"},
-      %{id: 6, name: "Baz"}
+      %{id: 6, name: "Baz"},
+      %{id: 7, name: "Foo"}
     ]
 
     socket =


### PR DESCRIPTION
Use `"normalisedlabel item_id"` as `:gb_tree` keys. This avoids crashing if duplicate (normalised) labels are used.

(I separate the normalised label and id with a space so that we can easily distinguish between label and id when searching. Spaces are removed from the label - so I know everything before the space is searchable.)

Try it out on liveview:
```elixir
#mix.exs
      {:searchable_select, github: "Flickswitch/searchable-select", branch: "louis/refactor/allow-duplicate-normalised-labels"},

```