### PR TITLE
Add `limit` attribute

### DIFF
--- a/lib/searchable_select.html.heex
+++ b/lib/searchable_select.html.heex
@@ -71,19 +71,7 @@
     >
       <%# dropdown options %>
       <div class="flex flex-col w-full overflow-y-auto max-h-64">
-        <%= if length(@visible_options) == 0 do %>
-          <div class="w-full border-gray-200 border-b">
-            <div class="flex w-full items-center p-2 pl-2 border-transparent border-l-2 relative">
-              <div class="w-full items-center flex justify-between">
-                <%= if String.trim(@search) == "" do
-                  "No more options."
-                else
-                  @no_matching_options_text || "Sorry, no matching options."
-                end %>
-              </div>
-            </div>
-          </div>
-        <% else %>
+        <%= if Enum.any?(@visible_options) do %>
           <%= for {option_key, option_val} <- @visible_options do %>
             <div class="overflow-none shrink-0" id={get_option_id(@id, option_val, @id_key)} phx-click={selection_action(option_key, @myself, @id, @multiple)}>
               <div class="cursor-pointer w-full border-gray-200 border-b hover:bg-primary-400 hover:text-white">
@@ -95,6 +83,31 @@
               </div>
             </div>
           <% end %>
+          <%= if @limit_hit? && @limit_hit_text do %>
+            <div class="overflow-none shrink-0">
+              <div class="overflow-none shrink-0" id={"#{@id}-remove-limit-option"} phx-click="remove_limit" phx-target={@myself}>
+                <div class="cursor-pointer w-full border-gray-200 border-b hover:bg-primary-400 hover:text-white">
+                  <div class="flex w-full items-center p-2 pl-2 border-transparent border-l-2 relative">
+                    <div class="w-full items-center flex justify-between">
+                      <%= @limit_hit_text %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="w-full border-gray-200 border-b">
+            <div class="flex w-full items-center p-2 pl-2 border-transparent border-l-2 relative">
+              <div class="w-full items-center flex justify-between">
+                <%= if String.trim(@search) == "" do
+                  "No more options."
+                else
+                  @no_matching_options_text || "Sorry, no matching options."
+                end %>
+              </div>
+            </div>
+          </div>
         <% end %>
       </div>
     </div>

--- a/test/searchable_select_test.exs
+++ b/test/searchable_select_test.exs
@@ -7,10 +7,15 @@ defmodule SearchableSelect.SearchableSelectTest do
 
   setup :load_test_view
 
-  test "renders all options on load", %{live: live} do
+  test "renders all options below limit on load", %{live: live} do
     Enum.each(1..4, fn i -> assert has_element?(live, "#multi-option-#{i}") end)
     Enum.each(1..4, fn i -> assert has_element?(live, "#single-option-#{i}") end)
+    Enum.each(1..2, fn i -> assert has_element?(live, "#single_limited-option-#{i}") end)
+    Enum.each(3..4, fn i -> refute has_element?(live, "#single_limited-option-#{i}") end)
     Enum.each(1..4, fn i -> assert has_element?(live, "#dropdown-option-#{i}") end)
+
+    live |> element("#single_limited-remove-limit-option") |> render_click()
+    Enum.each(1..4, fn i -> assert has_element?(live, "#single_limited-option-#{i}") end)
   end
 
   test "search filters items in dropdown", %{live: live} do

--- a/test/support/test_view.ex
+++ b/test/support/test_view.ex
@@ -74,6 +74,13 @@ defmodule SearchableSelect.TestView do
       parent_key="selected_options"
     />
     <.live_component
+      id="single_limited"
+      module={SearchableSelect}
+      options={@options}
+      limit={2}
+      parent_key="selected_options"
+    />
+    <.live_component
       id="single_preselected"
       module={SearchableSelect}
       options={@options}


### PR DESCRIPTION
- Adds `limit` for only _displaying_ a certain amount of results
- Adds `limit_hit_text` which adds an option at the bottom for removing this limit, should the user want to
- Simplify some functions that this touches
- Add a test case
- Reorganise doc
