### PR TITLE
[FLI-4583] Searchable Select Styling

### DIFF
--- a/lib/searchable_select.html.heex
+++ b/lib/searchable_select.html.heex
@@ -5,7 +5,7 @@
         <%# selection pills %>
         <%= for {_, selected_val} = selected <- @selected do %>
           <div class="flex justify-center items-center m-1 font-medium py-1 px-1 bg-white rounded bg-gray-100 border">
-            <div class="text-xs font-normal leading-none max-w-full flex-initial">
+            <div class="text-xs font-normal max-w-full flex-initial">
               <%= @label_callback.(selected_val) %>
             </div>
             <.pop_cross component_id={@id} id_key={@id_key} selected={selected} target={@myself} />
@@ -13,7 +13,7 @@
         <% end %>
       <% else %>
         <%= unless @selected == [] do %>
-          <span class="py-1 px-2">
+          <span class="px-2">
             <%= @label_callback.(elem(hd(@selected), 1)) %>
           </span>
         <% end %>
@@ -22,7 +22,7 @@
       <div class="flex-1">
         <input
           placeholder={if !@multiple and length(@selected) > 0, do: "", else: @placeholder}
-          class="bg-transparent py-1 px-2 appearance-none outline-none h-full w-full text-gray-800"
+          class="bg-transparent py-[0.2rem] px-2 appearance-none outline-none h-full w-full text-gray-800 text-ellipsis"
           {if @disabled, do: [disabled: ""], else: []}
           id={"#{@id}-search"}
           phx-click={show_dropdown(%JS{}, @id)}


### PR DESCRIPTION
- Adjusted the height of the searchable select with the search placeholder and with a single selected option.
- Made the overflow into an ellipsis for the search placeholder.
- Removed unnecessary "leading-none" (text-xs includes that styling)

![Screenshot 2024-07-30 at 11 52 40](https://github.com/user-attachments/assets/c3712109-e6f8-4287-aa8e-22bf5073d5fb)

![Screenshot 2024-07-30 at 11 52 54](https://github.com/user-attachments/assets/9b1f4872-9482-4f8d-8346-a79ad2382f0e)

![image](https://github.com/user-attachments/assets/3136cf53-c183-49f4-8639-1ecea1646004)
