### PR TITLE
Avoid style inline/attribute

### DIFF
--- a/lib/searchable_select.html.heex
+++ b/lib/searchable_select.html.heex
@@ -63,12 +63,11 @@
 
   <div class="w-full px-4">
     <div
-      class="absolute border-x border-gray-200 bg-white z-40 w-full left-0 rounded-b"
+      class="absolute border-x border-gray-200 bg-white z-40 w-full left-0 rounded-b hidden"
       id={"#{@id}-dropdown"}
       phx-click-away={hide_dropdown(@id)}
       phx-window-keydown={hide_dropdown(@id)}
       phx-key="escape"
-      style="display: none"
     >
       <%# dropdown options %>
       <div class="flex flex-col w-full overflow-y-auto max-h-64">


### PR DESCRIPTION
Simple enough; the JS show/hide commands [here](https://github.com/Flickswitch/searchable-select/blob/af25080a845f156f3bffb9f3c1917dcf4654fb3f/lib/searchable_select.ex#L264) still work 